### PR TITLE
Fix listener registration

### DIFF
--- a/src/main/kotlin/de/dasphiller/challengeAddon/mods/DamageRandomEffect.kt
+++ b/src/main/kotlin/de/dasphiller/challengeAddon/mods/DamageRandomEffect.kt
@@ -25,14 +25,14 @@ class DamageRandomEffect : Challenge {
     }
 
     override fun register() {
-        damage
+        damage.register()
     }
 
     override fun unregister() {
         damage.unregister()
     }
 
-    private val damage = listen<EntityDamageEvent>() {
+    private val damage = listen<EntityDamageEvent>(register = false) {
         if (it.entity !is Player) return@listen
         val player: Player = it.entity as Player
         if (player.isBlocking) return@listen


### PR DESCRIPTION
Listeners register automatically on initial class loading but it only should register inside the register function